### PR TITLE
feat: 99MotiveU 250514 1문제

### DIFF
--- a/99MotiveU/250514_유연근무제.java
+++ b/99MotiveU/250514_유연근무제.java
@@ -1,0 +1,20 @@
+class Solution {
+    public int solution(int[] schedules, int[][] timelogs, int startday) {
+        int answer = 0;
+        for (int i = 0; i < schedules.length; i++) {
+            boolean ok = true;
+            for (int j = 0; j < 7; j++) {
+                int d = (startday - 1 + j) % 7 + 1;
+                if (d == 6 || d == 7) continue;
+                int h = schedules[i] / 100, m = schedules[i] % 100 + 10;
+                int limit = (m >= 60 ? (h + 1) * 100 + (m - 60) : h * 100 + m);
+                if (timelogs[i][j] > limit) {
+                    ok = false;
+                    break;
+                }
+            }
+            if (ok) answer++;
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
유연근무제 문제는 반복문으로 시간 계산과 요일 계산을 처리하고 각 직원이 평일 동안 출근 희망 시각 +10분 이내에 출근 했는지 검사합니다.  출근 인정 시각은 시와 분으로 분리해 60분 초과 시 시간 이월 처리하고, 이벤트 시작 요일부터 하루씩 계산하며 주말은 건너 뛰고 모든 평일에 지각을 하지 않았다면 answer에 누적하도록 풀이했습니다.